### PR TITLE
[Android] Keeping aspect ratio on image resize

### DIFF
--- a/android/src/main/java/com/remobile/splashscreen/RCTSplashScreen.java
+++ b/android/src/main/java/com/remobile/splashscreen/RCTSplashScreen.java
@@ -118,7 +118,7 @@ public class RCTSplashScreen extends ReactContextBaseJavaModule {
                 splashImageView.setMinimumHeight(display.getHeight());
                 splashImageView.setMinimumWidth(display.getWidth());
                 splashImageView.setBackgroundColor(Color.BLACK);
-                splashImageView.setScaleType(ImageView.ScaleType.FIT_XY);
+                splashImageView.setScaleType(ImageView.ScaleType.CENTER_CROP);
 
                 // Create and show the dialog
                 splashDialog = new Dialog(context, translucent ? android.R.style.Theme_Translucent_NoTitleBar_Fullscreen : android.R.style.Theme_Translucent_NoTitleBar);


### PR DESCRIPTION
This is a Android-only "fix" for now. The iOS scaling already works differently, so both changes can arguably be done independently.

Before:

<img width="888" alt="screen shot 2017-08-31 at 17 49 00" src="https://user-images.githubusercontent.com/1573409/29946944-b785335e-8e7d-11e7-8fd2-63a443e7d129.png">

After:

<img width="891" alt="screen shot 2017-08-31 at 17 56 02" src="https://user-images.githubusercontent.com/1573409/29946965-cfcb7c2a-8e7d-11e7-86d4-ec162a9a4431.png">
